### PR TITLE
Make window responsible for renderer, remove renderer from application.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ project(${CMAKE_PROJECT_NAME})
 
 set(PLATFORM_INCLUDES
 	"${PROJECT_SOURCE_DIR}/platform/"
+	"${PROJECT_SOURCE_DIR}/platform/events/"
 	"${PROJECT_SOURCE_DIR}/platform/render/"
 	"${PROJECT_SOURCE_DIR}/platform/render/texture"
 	"${PROJECT_SOURCE_DIR}/platform/utils/"

--- a/src/app/application/Application.cpp
+++ b/src/app/application/Application.cpp
@@ -35,8 +35,7 @@ namespace SDLGame
 
 	void Application::initObjects()
 	{
-		mWindow.init("Test Window", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 640, 480, 0);
-		mRenderer.init(mWindow.getWindow(), SDL_RENDERER_ACCELERATED);
+		mWindow->init("Test Window", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 640, 480, 0);
 	}
 
 	void Application::runLoop()
@@ -53,18 +52,15 @@ namespace SDLGame
 				{
 					isRunning = false;
 				}
-				mRenderer.renderFlush();
-
-				mRenderer.renderPresent();
 			}
+			mWindow->render();
 		}
 		shutdown();
 	}
 
 	void Application::shutdown()
 	{
-		mWindow.destroy();
-		mRenderer.destroy();
+		mWindow->destroy();
 
 		IMG_Quit();
 		Mix_Quit();

--- a/src/app/application/Application.hpp
+++ b/src/app/application/Application.hpp
@@ -29,8 +29,6 @@ namespace SDLGame
 
 		void shutdown();
 
-		Window mWindow;
-
-		Renderer mRenderer;
+		std::unique_ptr<Window> mWindow = std::make_unique<Window>();
 	};
 }

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -5,12 +5,14 @@ include_directories(
 )
 
 set(PLATFORM_SOURCES
+	"events/EventHandler.cpp"
 	"render/Renderer.cpp"
 	"render/texture/Texture.cpp"
 	"window/Window.cpp"
 )
 
 set(PLATFORM_HEADERS
+	"events/EventHandler.hpp"
 	"render/Renderer.hpp"
 	"render/texture/Texture.hpp"
 	"utils/Paths.hpp"

--- a/src/platform/events/EventHandler.hpp
+++ b/src/platform/events/EventHandler.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <SDL_events.h>
+
+namespace SDLGame
+{
+	class EventHandler
+	{
+	public:
+	private:
+		SDL_Event* event;
+	};
+}

--- a/src/platform/window/Window.cpp
+++ b/src/platform/window/Window.cpp
@@ -19,10 +19,19 @@ namespace SDLGame
 		{
 			destroy();
 		}
+		mRenderer->init(mWindow, SDL_RENDERER_ACCELERATED);
+	}
+
+	void Window::render()
+	{
+		mRenderer->renderFlush();
+		mRenderer->renderPresent();
 	}
 
 	void Window::destroy()
 	{
+		mRenderer->destroy();
+
 		SDL_DestroyWindow(mWindow);
 		mWindow = NULL;
 	}

--- a/src/platform/window/Window.hpp
+++ b/src/platform/window/Window.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <SDL_video.h>
+#include <memory>
 
 #include "Types.hpp"
 #include "Renderer.hpp"
@@ -15,10 +16,14 @@ namespace SDLGame
 
 		void init (const char* title, u32 x, u32 y, u16 w, u16 h, u32 flags);
 
+		void render();
+
 		void destroy();
 
 		SDL_Window* getWindow() { return mWindow; }
 	private:
 		SDL_Window* mWindow;
+
+		std::unique_ptr<Renderer> mRenderer = std::make_unique<Renderer>();
 	};
 }


### PR DESCRIPTION
allows the window to handle renderer destruction, since the renderer requires the window in the first place.